### PR TITLE
Make the stub ignored by sorbet-static

### DIFF
--- a/lib/sorbet-runtime-stub.rb
+++ b/lib/sorbet-runtime-stub.rb
@@ -1,3 +1,5 @@
+# typed: ignore
+
 module T
   class << self
     def absurd(value); end


### PR DESCRIPTION
So there are no error with sorbet-static when this file is vendored.