### PR TITLE
Prevent loading the stub definitions if `sorbet-runtime` is loadable

### DIFF
--- a/lib/sorbet-runtime-stub.rb
+++ b/lib/sorbet-runtime-stub.rb
@@ -51,7 +51,7 @@ module T
   end
 
   module Sig
-    def sig(&blk); end
+    def sig(arg0=nil, &blk); end
   end
 
   module Helpers

--- a/lib/sorbet-runtime-stub.rb
+++ b/lib/sorbet-runtime-stub.rb
@@ -1,5 +1,11 @@
 # typed: ignore
 
+begin
+  gem "sorbet-runtime"
+  return
+rescue Gem::LoadError
+end
+
 module T
   class << self
     def absurd(value); end


### PR DESCRIPTION
We never want the stub definitions to override the actual `sorbet-runtime` definitions, but the library does not protect against it in its current state.

Adding a check to see if the `sorbet-runtime` gem is loadable in the current context can tell us if we should load the stub definitions or not, which is what this PR is doing.

I am also including a fix for the signature of the `sig` method.