### PR TITLE
Add recipe for conditionally requiring the stubs in gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ end
 ```
 and add `sorbet-runtime` to your `Gemfile` only for `development` and `test` groups.
 
+If you are developing a gem that uses Sorbet in development but don't want the runtime typechecking to affect other code, you can conditionally load the runtime stubs at the top of your gem's code:
+```ruby
+require 'sorbet-runtime-stub' unless defined?(T)
+```
+You can then require the regular `sorbet-runtime` in your development-only files (e.g. test helpers, Rakefiles).
+
 ## Missing features
 
 Some feature from sorbet-runtime like `T::Enum` and `T::Struct` as still not supported.


### PR DESCRIPTION
It took me a few tries to figure out the best way to include the stubs in a gem I'm developing.  My goal was to have strict typechecking during development, but no typechecking when imported into a larger project.  This is working nicely for me and thought I'd share since it's probably a pretty common use case.

(Thanks for all your work on sorbet tooling!)